### PR TITLE
Cleanup long tracebacks and 100% code coverage!

### DIFF
--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -525,7 +525,9 @@ def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseExcepti
         # We are still observing frames from inside the module; keep looking
         tb = previous_tb
 
-    return type(original_exception)(*original_exception.args).with_traceback(previous_tb)
+    return type(original_exception)(*original_exception.args).with_traceback(
+        previous_tb
+    )
 
 
 class PipeNode(FunctionNode):
@@ -665,6 +667,7 @@ class PipeNode(FunctionNode):
             return self._function(**kwargs)
         except BaseException as e:
             raise _exception_with_cleaned_tb(e) from None
+
 
 # -------------------------------------------------------------------------------
 # decorator utilities
@@ -869,6 +872,7 @@ def _descriptor_factory(
 
 # -------------------------------------------------------------------------------
 # decorators
+
 
 def pipe_node_factory(
     *key_positions: KeyPostion,

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -99,7 +99,7 @@ def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseExcepti
         # We are still observing frames from inside the module; keep looking
         tb = tb_next
 
-    return type(original_exception)(*original_exception.args).with_traceback(tb_next)
+    return original_exception.__class__(*original_exception.args).with_traceback(tb_next)
 
 
 _BINARY_OP_MAP = {

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -74,7 +74,7 @@ def _from_this_module(tb: types.TracebackType) -> bool:
     return tb.tb_frame.f_code.co_filename == __file__
 
 
-def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseException:
+def _exception_with_cleaned_tb(original_exception: Exception) -> Exception:
     """
     Return back a new exception, where traceback is pointing to the first frame with code originating outside this module.
     """
@@ -292,7 +292,7 @@ class FunctionNode:
         """
         try:
             return self._function(*args, **kwargs)
-        except BaseException as e:
+        except Exception as e:
             raise _exception_with_cleaned_tb(e) from None
 
     def __str__(self: FN) -> str:
@@ -652,7 +652,7 @@ class PipeNode(FunctionNode):
         if self._call_state is PipeNode.State.FACTORY:
             try:
                 return self._function(*args, **kwargs)
-            except BaseException as e:
+            except Exception as e:
                 raise _exception_with_cleaned_tb(e) from None
 
         if args or set(kwargs) - PIPE_NODE_KWARGS != set():
@@ -662,7 +662,7 @@ class PipeNode(FunctionNode):
 
         try:
             return self._function(**kwargs)
-        except BaseException as e:
+        except Exception as e:
             raise _exception_with_cleaned_tb(e) from None
 
 

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -70,8 +70,8 @@ def _wrap_binary(func: tp.Callable[[FN, tp.Any], FN]) -> tp.Callable[[FN, tp.Any
     return binary
 
 
-def _from_this_module(some_tb: types.TracebackType) -> bool:
-    return some_tb.tb_frame.f_code.co_filename == __file__
+def _from_this_module(tb: types.TracebackType) -> bool:
+    return tb.tb_frame.f_code.co_filename == __file__
 
 
 def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseException:

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -930,8 +930,7 @@ def pipe_node_factory(
         decorated_core_callable = core_decorator(core_callable)
 
         def factory_f(*f_args: tp.Any, **f_kwargs: tp.Any) -> PipeNode:
-            """
-            This is the function returned by the decorator, used to create the PipeNode that resides in expressions after being called with arguments.
+            """This is the function returned by the decorator, used to create the PipeNode that resides in expressions after being called with arguments.
 
             f_args and f_kwargs are passed to the core_callable; if f_args or f_kwargs are PipeNode instances, they will be called with the processing args and kwargs (including PN_INPUT), either from process_f or (if innermost) from expression args.
             """
@@ -941,8 +940,7 @@ def pipe_node_factory(
                 )
 
             def expression_f(**e_kwargs: tp.Any) -> PipeNode:
-                """
-                This is the PipeNode that resides in expressions prior to `|` operator evalation.
+                """This is the PipeNode that resides in expressions prior to `|` operator evalation.
                 When called with `|`, the predecessor is passed is in e_kwargs as PREDECESSOR_PN. In this usage the e_args will always be empty.
 
                 When in the innermost position, expression_f is never called with `|` but with the PN_INPUT; this sitation is identified and the core_callable is called immediately.

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -82,7 +82,7 @@ def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseExcepti
     assert tb is not None
     tb_next = None
 
-    assert _from_this_module(tb) # Sanity
+    assert _from_this_module(tb)  # Sanity
 
     while True:
         tb_next = tb.tb_next
@@ -99,9 +99,7 @@ def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseExcepti
         # We are still observing frames from inside the module; keep looking
         tb = tb_next
 
-    return type(original_exception)(*original_exception.args).with_traceback(
-        tb_next
-    )
+    return type(original_exception)(*original_exception.args).with_traceback(tb_next)
 
 
 _BINARY_OP_MAP = {

--- a/function_pipe/core/function_pipe.py
+++ b/function_pipe/core/function_pipe.py
@@ -505,28 +505,27 @@ def _exception_with_cleaned_tb(original_exception: BaseException) -> BaseExcepti
     """
     tb = original_exception.__traceback__
     assert tb is not None
-    previous_tb = None
+    tb_next = None
 
     assert _from_module(tb)
 
     while True:
-        previous_tb = tb.tb_next
+        tb_next = tb.tb_next
 
-        # If `previous_tb` is None, it means everything from the stack came from this module.
+        # If `tb_next` is None, it means everything from the stack came from this module.
         # Use the original exception
-        if previous_tb is None:
-            tb = original_exception.__traceback__
-            break
+        if tb_next is None:
+            return original_exception
 
-        # If `previous_tb` originates from outside the module, it means we are done looking
-        if not _from_module(previous_tb):
+        # If `tb_next` originates from outside the module, it means we are done looking
+        if not _from_module(tb_next):
             break
 
         # We are still observing frames from inside the module; keep looking
-        tb = previous_tb
+        tb = tb_next
 
     return type(original_exception)(*original_exception.args).with_traceback(
-        previous_tb
+        tb_next
     )
 
 

--- a/function_pipe/test/test_function_pipe.py
+++ b/function_pipe/test/test_function_pipe.py
@@ -4,6 +4,7 @@
 # pylint: disable=pointless-string-statement, pointless-statement
 # pylint: disable=C0328
 import functools
+import traceback
 import types
 import unittest
 
@@ -11,7 +12,7 @@ from function_pipe.core import function_pipe as fpn  # pylint: disable=E0401
 
 
 class TestUnit(unittest.TestCase):
-    def test_basic_expressions_a(self):
+    def test_basic_expressions_a(self) -> None:
         class TestInput(fpn.PipeNodeInput):
             def get_origin(self):
                 return 32
@@ -73,7 +74,7 @@ class TestUnit(unittest.TestCase):
         post = f(pn_input=pni)
         self.assertEqual(post, 32)
 
-    def test_basic_expressions_b(self):
+    def test_basic_expressions_b(self) -> None:
         @fpn.pipe_node
         def foo1(**kwargs):
             return 12
@@ -85,7 +86,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(12, (bar1 | foo1)[None])
         self.assertEqual(13, (foo1 | bar1)[None])
 
-    def test_basic_expressions_c(self):
+    def test_basic_expressions_c(self) -> None:
         @fpn.pipe_node(fpn.PN_INPUT)
         def foo2(pni):
             return pni
@@ -96,7 +97,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(27 * 2, (foo2 | bar2)[27])
 
-    def test_basic_expressions_d(self):
+    def test_basic_expressions_d(self) -> None:
         @fpn.pipe_node(fpn.PN_INPUT)
         def foo3(pni):
             return pni
@@ -107,7 +108,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(27 * 2, (foo3 | bar3)[27])
 
-    def test_basic_expressions_e(self):
+    def test_basic_expressions_e(self) -> None:
         @fpn.pipe_node_factory
         def foo4(arg, **kwargs):
             return 12 + arg
@@ -119,7 +120,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(12 + 7, (bar4(6) | foo4(7))[None])
         self.assertEqual(13 - 6, (foo4(7) | bar4(6))[None])
 
-    def test_basic_expressions_f(self):
+    def test_basic_expressions_f(self) -> None:
         @fpn.pipe_node_factory(fpn.PN_INPUT)
         def foo5(pni, arg):
             return pni + arg
@@ -130,7 +131,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(27 * 2 + 8 - 2, (foo5(8) | bar5(2))[27])
 
-    def test_basic_expressions_g(self):
+    def test_basic_expressions_g(self) -> None:
         @fpn.pipe_node_factory(fpn.PN_INPUT)
         def foo6(pni, arg):
             return pni + arg
@@ -141,7 +142,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(27 * 2 + 8 - 2, (foo6(8) | bar6(2))[27])
 
-    def test_methods_defined_on_classes(self):
+    def test_methods_defined_on_classes(self) -> None:
 
         uno_mismo_pipe_node = functools.partial(fpn.pipe_node, self_keyword="uno_mismo")
         uno_mismo_pipe_node_factory = functools.partial(
@@ -407,7 +408,7 @@ class TestUnit(unittest.TestCase):
                 uno_mismo="re-provided", **{fpn.PN_INPUT: pni}
             )
 
-    def test_bound_and_unbound_pipe_nodes(self):
+    def test_bound_and_unbound_pipe_nodes(self) -> None:
         @fpn.pipe_node
         def pn_unbound(**kwargs):
             return kwargs[fpn.PN_INPUT]
@@ -429,7 +430,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(pn_unbound[pni], pn_bound[pni])
         self.assertEqual(pnf_unbound("fval")[pni], pnf_bound("fval")[pni])
 
-    def test_complex_pipeline(self):
+    def test_complex_pipeline(self) -> None:
         @fpn.pipe_node_factory(fpn.PREDECESSOR_RETURN)
         def multiply(prev, val):
             return prev * val
@@ -528,7 +529,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(pni.store_items, dict(A=A, B=B, C=C, D=D).items())
 
-    def test_core_decorator(self):
+    def test_core_decorator(self) -> None:
         # Modify the core_decorators
         found_f = set()
 
@@ -646,11 +647,13 @@ class TestUnit(unittest.TestCase):
             found_f,
         )
 
-    def test_repr_a(self):
+    def test_pn_repr_a(self) -> None:
         @fpn.pipe_node_factory()
         def factory(arg1, arg2, *, kwarg):
             pass
 
+        self.assertEqual("<PNF: factory>", str(factory))
+        self.assertEqual("<PNF: factory>", repr(factory))
         self.assertEqual("<PN: factory(1,2,kwarg=3)>", repr(factory(1, 2, kwarg=3)))
         self.assertEqual(
             "<PN: factory(1,2,kwarg=3) | factory(1,2,kwarg=3)>",
@@ -694,7 +697,7 @@ class TestUnit(unittest.TestCase):
             str(pn1 | pn2 | pn3(*args, **kwargs) | pn2 | pn1),
         )
 
-    def test_repr_b(self):
+    def test_pn_repr_b(self) -> None:
         @fpn.pipe_node()
         def a():
             return 1
@@ -779,7 +782,7 @@ class TestUnit(unittest.TestCase):
         )
         self.assertEqual("<PN: -d==e>", repr(complex_e))
 
-    def test_repr_c(self):
+    def test_pn_repr_c(self) -> None:
         lambda_func = lambda x: x + 2
         fn = fpn.pipe_node(lambda_func)
         self.assertEqual("<PN: lambda_func = lambda x: x + 2>", repr(fn))
@@ -788,7 +791,7 @@ class TestUnit(unittest.TestCase):
             repr(fpn.pipe_node(lambda x: x + 2)),
         )  # Isn't really an easy way to parse the lambda expression alone.
 
-    def test_cannot_store_twice(self):
+    def test_cannot_store_twice(self) -> None:
         @fpn.pipe_node()
         def pn():
             return 12
@@ -798,7 +801,7 @@ class TestUnit(unittest.TestCase):
         with self.assertRaises(KeyError):
             (pn | fpn.store("a") | fpn.store("a"))[pni]
 
-    def test_call(self):
+    def test_call(self) -> None:
         calls = []
 
         @fpn.pipe_node(fpn.PN_INPUT)
@@ -825,7 +828,7 @@ class TestUnit(unittest.TestCase):
 
         self.assertListEqual(["pn1", "pn2", "pn3"], calls)
 
-    def test_invalid_operations(self):
+    def test_invalid_operations(self) -> None:
         @fpn.pipe_node()
         def pn1():
             pass
@@ -852,7 +855,7 @@ class TestUnit(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             pn1.partial(1, 2, a=3, b=4)
 
-    def test_pn_states(self):
+    def test_pn_states(self) -> None:
         @fpn.pipe_node_factory()
         def factory(*args, **kwargs):
             pass
@@ -865,7 +868,7 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(fpn.PipeNode.State.EXPRESSION, pn.call_state)
         self.assertEqual(fpn.PipeNode.State.FACTORY, factory.call_state)
 
-    def test_predecessor_property(self):
+    def test_predecessor_property(self) -> None:
         testable = {}
 
         @fpn.pipe_node()
@@ -888,7 +891,7 @@ class TestUnit(unittest.TestCase):
         expr[None]
         self.assertEqual({"pn1": pn1.predecessor, "pn2": pn2.predecessor}, testable)
 
-    def test_ror(self):
+    def test_ror(self) -> None:
         class MissingOR:
             def __init__(self, state):
                 self.state = state
@@ -910,7 +913,7 @@ class TestUnit(unittest.TestCase):
         post = expr["pni"]
         self.assertEqual(343, post)
 
-    def test_invalid_factories(self):
+    def test_invalid_factories(self) -> None:
         @fpn.pipe_node_factory
         def bad_factory_a(**kwargs):
             pass
@@ -946,7 +949,7 @@ class TestUnit(unittest.TestCase):
         with self.assertRaises(ValueError):
             bad_factory_a()(pn_input=True, predecessor_return=True)
 
-    def test_invalid_pn_call(self):
+    def test_invalid_pn_call(self) -> None:
         @fpn.pipe_node()
         def pn_a():
             pass
@@ -967,7 +970,179 @@ class TestUnit(unittest.TestCase):
         with self.assertRaises(ValueError):
             pn_b(kwarg=13)  # pylint: disable=unexpected-keyword-arg
 
-    def test_unwrapping(self):
+    def test_compose(self) -> None:
+        def square(x: int) -> int:
+            return x**2
+
+        def half(x: int) -> int:
+            return x // 2
+
+        functions = (square, half, half, square, half)
+
+        fnA = fpn.compose(*functions)
+        assert fnA(14) == square(half(half(square(half(14))))) == 144
+
+        fnB = fpn.compose(*reversed(functions))
+        assert fnB(14) == half(square(half(half(square(14))))) == 1200
+
+    def test_fn_str_repr(self) -> None:
+        def inc(x):
+            return x + 1
+
+        def square(x: int) -> int:
+            return x**2
+
+        def half(x: int) -> int:
+            return x // 2
+
+        fnA = fpn.compose(square, half, half, square, half)
+        fnB = fpn.FunctionNode(inc)
+        fnC = fnA >> fnB
+        fnD = fnB + fnA
+
+        self.assertEqual(str(fnA), repr(fnA))
+        self.assertEqual(str(fnB), repr(fnB))
+        self.assertEqual(str(fnC), repr(fnC))
+        self.assertEqual(str(fnD), repr(fnD))
+
+        self.assertEqual(str(fnA), "<FN: compose(half,square,half,half,square)>")
+        self.assertEqual(str(fnB), "<FN: inc>")
+        self.assertEqual(str(fnC), "<FN: compose(compose(half,square,half,half,square),inc)>")
+        self.assertEqual(str(fnD), "<FN: inc+(compose(half,square,half,half,square))>")
+
+    def test_fn_partialling(self) -> None:
+        def func(a, b, *, c, d=0):
+            print(a, b, c, d)
+            return a + b + c + d
+
+        fnA = fpn.FunctionNode(func)
+        self.assertEqual(fnA(1, 2, c=3, d=4), 10)
+
+        fnB = fnA + fnA
+        self.assertEqual(fnB(1, 2, c=3, d=4), 20)
+
+        fnC = fnA >> fnB
+        with self.assertRaises(TypeError):
+            fnC(1, 2, c=3, d=4)
+
+        fnD = fnA >> fnB.partial(20, c=30, d=40)
+        self.assertEqual(fnD(1, 2, c=3, d=4), 200)
+
+    def test_exception_with_cleaned_tb(self) -> None:
+        class TestingError(RuntimeError):
+            pass
+
+        def func():
+            raise TestingError("Testing")
+
+        try:
+            func()
+        except TestingError as e:
+            # We can not give this function arbitrary exceptions. It requires
+            # exceptions caught from _inside_ function_pipe.py
+            with self.assertRaises(AssertionError):
+                fpn._exception_with_cleaned_tb(e)
+
+        node = fpn.FunctionNode(func)
+
+        try:
+            node()
+        except TestingError as e:
+            frame_reprs = traceback.format_tb(e.__traceback__)
+
+        self.assertEqual(len(frame_reprs), 3)
+        self.assertIn("test_function_pipe.py", frame_reprs[0])
+        self.assertIn("test_exception_with_cleaned_tb", frame_reprs[0])
+        self.assertNotIn("test_function_pipe.py", frame_reprs[1])
+        self.assertIn("function_pipe.py", frame_reprs[1])
+        self.assertIn("_exception_with_cleaned_tb", frame_reprs[1])
+        self.assertIn("test_function_pipe.py", frame_reprs[2])
+        self.assertIn("TestingError", frame_reprs[2])
+
+    def test_fn_operators_a(self) -> None:
+        fn = fpn.FunctionNode(lambda x: x + 1)
+
+        self.assertEqual((fn + 3)(1), 2 + 3)
+        self.assertEqual((3 + fn)(1), 3 + 2)
+        self.assertEqual((fn - 3)(1), 2 - 3)
+        self.assertEqual((3 - fn)(1), 3 - 2)
+        self.assertEqual((fn * 3)(1), 2 * 3)
+        self.assertEqual((3 * fn)(1), 3 * 2)
+        self.assertEqual((fn / 3)(1), 2 / 3)
+        self.assertEqual((3 / fn)(1), 3 / 2)
+
+    def test_fn_operators_b(self) -> None:
+        half = fpn.FunctionNode(lambda x: x // 2)
+        square = lambda x: x ** 2
+
+        self.assertEqual((half >> square)(1), square(half(1)))
+        self.assertEqual((square >> half)(1), half(square(1)))
+
+        self.assertEqual((half << square)(1), half(square(1)))
+        self.assertEqual((square << half)(1), square(half(1)))
+
+        with self.assertRaises(NotImplementedError):
+            half | square
+
+        with self.assertRaises(NotImplementedError):
+            square | half
+
+    def test_is_unbound_self_method(self) -> None:
+
+        def classmethod_func(cls):
+            pass
+
+        def staticmethod_func():
+            pass
+
+        class TestClass:
+            def m_self(self):
+                pass
+
+            def m_uno_mismo(uno_mismo):
+                pass
+
+            @classmethod
+            def m_classmethod_a(cls):
+                pass
+
+            @staticmethod
+            def m_staticmethod_a():
+                pass
+
+            m_classmethod_b = classmethod(classmethod_func)
+            m_staticmethod_b = staticmethod(staticmethod_func)
+
+        m_classmethod_c = classmethod(classmethod_func)
+        m_staticmethod_c = staticmethod(staticmethod_func)
+
+        func_self = functools.partial(fpn._is_unbound_self_method, self_keyword="self")
+        func_uno_mismo = functools.partial(fpn._is_unbound_self_method, self_keyword="uno_mismo")
+
+        self.assertTrue(func_self(TestClass.m_self))
+        self.assertFalse(func_uno_mismo(TestClass.m_self))
+        self.assertFalse(func_self(TestClass.m_uno_mismo))
+        self.assertTrue(func_uno_mismo(TestClass.m_uno_mismo))
+
+        self.assertFalse(func_self(TestClass.m_classmethod_a))
+        self.assertFalse(func_uno_mismo(TestClass.m_classmethod_a))
+        self.assertFalse(func_self(TestClass.m_staticmethod_a))
+        self.assertFalse(func_uno_mismo(TestClass.m_staticmethod_a))
+
+        self.assertFalse(func_self(TestClass.m_classmethod_b))
+        self.assertFalse(func_uno_mismo(TestClass.m_classmethod_b))
+        self.assertFalse(func_self(TestClass.m_staticmethod_b))
+        self.assertFalse(func_uno_mismo(TestClass.m_staticmethod_b))
+
+        self.assertFalse(func_self(m_classmethod_c))
+        self.assertFalse(func_uno_mismo(m_classmethod_c))
+        self.assertFalse(func_self(m_staticmethod_c))
+        self.assertFalse(func_uno_mismo(m_staticmethod_c))
+
+        self.assertFalse(func_self(functools.partial(classmethod_func, cls=None)))
+        self.assertFalse(func_uno_mismo(functools.partial(classmethod_func, cls=None)))
+
+    def test_unwrapping(self) -> None:
         @fpn.pipe_node
         def pn1(*args, **kwargs):
             return 1
@@ -994,7 +1169,7 @@ class TestUnit(unittest.TestCase):
         test_pn1(pn2 | pn1)
         test_pn1(pn2 | pn4() | pn1)
 
-        def test_pn2(pn_or_expr):
+        def test_pn2(pn_or_expr) -> None:
             with self.assertRaises(KeyError):
                 pn_or_expr.unwrap(1, 2)
 
@@ -1009,7 +1184,7 @@ class TestUnit(unittest.TestCase):
         test_pn2(pn1 | pn2)
         test_pn2(pn1 | pn3() | pn2)
 
-        def test_pn3(pn_or_expr):
+        def test_pn3(pn_or_expr) -> None:
             with self.assertRaises(KeyError):
                 pn_or_expr.unwrap(1, b=2, c=8)  # Missing predecessor_return
 
@@ -1024,7 +1199,7 @@ class TestUnit(unittest.TestCase):
         test_pn3(pn2 | pn4(1) | pn3())
 
         # pn4
-        def test_pn4(pn_or_expr):
+        def test_pn4(pn_or_expr) -> None:
             with self.assertRaises(KeyError):
                 pn_or_expr.unwrap(1)  # Missing predecessor_return
 
@@ -1040,7 +1215,3 @@ class TestUnit(unittest.TestCase):
         test_pn4(pn4)
         test_pn4(pn2 | pn4())
         test_pn4(pn1 | pn3() | pn4())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/function_pipe/test/test_function_pipe.py
+++ b/function_pipe/test/test_function_pipe.py
@@ -1007,7 +1007,9 @@ class TestUnit(unittest.TestCase):
 
         self.assertEqual(str(fnA), "<FN: compose(half,square,half,half,square)>")
         self.assertEqual(str(fnB), "<FN: inc>")
-        self.assertEqual(str(fnC), "<FN: compose(compose(half,square,half,half,square),inc)>")
+        self.assertEqual(
+            str(fnC), "<FN: compose(compose(half,square,half,half,square),inc)>"
+        )
         self.assertEqual(str(fnD), "<FN: inc+(compose(half,square,half,half,square))>")
 
     def test_fn_partialling(self) -> None:
@@ -1073,7 +1075,7 @@ class TestUnit(unittest.TestCase):
 
     def test_fn_operators_b(self) -> None:
         half = fpn.FunctionNode(lambda x: x // 2)
-        square = lambda x: x ** 2
+        square = lambda x: x**2
 
         self.assertEqual((half >> square)(1), square(half(1)))
         self.assertEqual((square >> half)(1), half(square(1)))
@@ -1088,7 +1090,6 @@ class TestUnit(unittest.TestCase):
             square | half
 
     def test_is_unbound_self_method(self) -> None:
-
         def classmethod_func(cls):
             pass
 
@@ -1117,7 +1118,9 @@ class TestUnit(unittest.TestCase):
         m_staticmethod_c = staticmethod(staticmethod_func)
 
         func_self = functools.partial(fpn._is_unbound_self_method, self_keyword="self")
-        func_uno_mismo = functools.partial(fpn._is_unbound_self_method, self_keyword="uno_mismo")
+        func_uno_mismo = functools.partial(
+            fpn._is_unbound_self_method, self_keyword="uno_mismo"
+        )
 
         self.assertTrue(func_self(TestClass.m_self))
         self.assertFalse(func_uno_mismo(TestClass.m_self))


### PR DESCRIPTION
This PR does 3 things:

1. Removes (when possible/applicable) tons of unhelpful traceback frames when errors are raised.
2. Gets the code to 100% code coverage
3. Updates an error message with a better help suggestion

For example, this is a possible traceback that user might see when using pipe nodes:
```
| <function init at 0x7f4f974011f0>
| <function add_pni at 0x7f4f971de160>
Traceback (most recent call last):
  File "script.py", line 74, in <module>
    post = expr[pni]
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 646, in __getitem__
    return self(**{PN_INPUT: pn_input})
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 976, in process_f
    predecessor_return = predecessor_pn(*p_args, **p_kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 664, in __call__
    return self._function(**kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 990, in process_f
    return decorated_core_callable(
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 709, in wrapped
    return core_callable(*args, **kwargs)
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 756, in wrapped
    return core_callable(*target_args, *args, **target_kwargs)
  File "script.py", line 47, in add_pni
    return hawk.function()
  File "/home/burkland/github/function-pipe/hawk.py", line 4, in function
    return charles.function()
  File "/home/burkland/github/function-pipe/charles.py", line 2, in function
    return 14 / 0
ZeroDivisionError: division by zero
```

This is extremely unhelpful. With the code changes made, the following traceback would be printed:
```
| <function init at 0x7fddb21e61f0>
| <function add_pni at 0x7fddb1fc3160>
Traceback (most recent call last):
  File "script.py", line 74, in <module>
    post = expr[pni]
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 646, in __getitem__
    return self(**{PN_INPUT: pn_input})
  File "/home/burkland/github/function-pipe/function_pipe/core/function_pipe.py", line 666, in __call__
    raise _exception_with_cleaned_tb(e) from None
  File "script.py", line 47, in add_pni
    return hawk.function()
  File "/home/burkland/github/function-pipe/hawk.py", line 4, in function
    return charles.function()
  File "/home/burkland/github/function-pipe/charles.py", line 2, in function
    return 14 / 0
ZeroDivisionError: division by zero
```