### PR TITLE
Fix Docs Search

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,6 @@ add_module_names = False
 # -- Options for HTML output ---------------------------------------------------
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Search was failing in docbot because of a sphinx_rtd_theme configuration problem.